### PR TITLE
Darwin Python Development Environment Setup

### DIFF
--- a/darwin/config.example.yml
+++ b/darwin/config.example.yml
@@ -64,5 +64,16 @@ github_work_ssh_host: "work"
 github_default_ssh_account: "personal"
 
 # Python Environment Configuration
-# Set to 'true' to configure Python development tools (pipx, poetry, tox)
+# Set to 'true' to configure Python development tools (pyenv, pipx, poetry, tox)
 configure_python: false
+
+# pyenv Configuration
+# Python versions to install with pyenv (optional)
+# Examples: "3.11.5", "3.12.0", "3.10.12"
+pyenv_python_versions:
+  - "3.11.5"
+  - "3.12.0"
+
+# Global Python version to set (optional)
+# This will be the default Python version used system-wide
+pyenv_global_version: "3.11.5"

--- a/darwin/config.example.yml
+++ b/darwin/config.example.yml
@@ -61,4 +61,8 @@ github_work_ssh_host: "work"
 # SSH Key Configuration
 # Set to 'personal' to use personal account with default SSH key (~/.ssh/id_ed25519)
 # Set to 'work' to use work account with default SSH key (~/.ssh/id_ed25519)
-github_default_ssh_account: "personal" 
+github_default_ssh_account: "personal"
+
+# Python Environment Configuration
+# Set to 'true' to configure Python development tools (pipx, poetry, tox)
+configure_python: false

--- a/darwin/main.yml
+++ b/darwin/main.yml
@@ -40,4 +40,8 @@
 
     - import_tasks: tasks/github-multi-identity.yml
       when: configure_github_multi_identity
-      tags: ['github', 'github-multi-identity'] 
+      tags: ['github', 'github-multi-identity']
+
+    - import_tasks: tasks/python.yml
+      when: configure_python
+      tags: ['python']

--- a/darwin/tasks/python.yml
+++ b/darwin/tasks/python.yml
@@ -95,15 +95,24 @@
 
 
 
-# Install Python versions if specified
-- name: Install specified Python versions with pyenv
-  shell: pyenv install {{ item }}
+# Check if Python versions are already installed
+- name: Check if Python versions are already installed
+  shell: pyenv versions --bare | grep -q "^{{ item }}$" || echo "not_installed"
   loop: "{{ pyenv_python_versions | default([]) }}"
   when: 
     - pyenv_python_versions is defined
     - pyenv_python_versions | length > 0
+  register: python_version_checks
+  changed_when: false
+
+# Install Python versions if specified and not already installed
+- name: Install specified Python versions with pyenv
+  shell: pyenv install {{ item.item }}
+  loop: "{{ python_version_checks.results | default([]) }}"
+  when: 
+    - python_version_checks is defined
+    - item.stdout == "not_installed"
   register: python_install_results
-  ignore_errors: true
 
 # Set global Python version if specified
 - name: Set global Python version
@@ -114,7 +123,7 @@
 # Rehash pyenv shims after installations
 - name: Rehash pyenv shims
   shell: pyenv rehash
-  when: python_install_results is defined and python_install_results | length > 0
+  when: python_install_results is defined and python_install_results.results | length > 0
 
 - name: Display installation results
   debug:
@@ -130,4 +139,10 @@
   debug:
     msg: "pyenv version: {{ pyenv_version_check.stdout | default('not available') }}"
   when: pyenv_version_check is defined and pyenv_version_check.stdout is defined
+
+- name: Display Python installation results
+  debug:
+    msg: "Python {{ item.item }}: {{ 'installed' if item.stdout != 'not_installed' else 'already exists' }}"
+  loop: "{{ python_version_checks.results | default([]) }}"
+  when: python_version_checks is defined
   

--- a/darwin/tasks/python.yml
+++ b/darwin/tasks/python.yml
@@ -44,6 +44,11 @@
     executable: "{{ pipx_path }}"
   register: poetry_install
 
+- name: Install poetry-plugin-export with pipx inject
+  shell: "{{ pipx_path }} inject poetry poetry-plugin-export"
+  register: poetry_plugin_export_install
+  changed_when: poetry_plugin_export_install.rc == 0
+
 - name: Install tox with pipx
   community.general.pipx:
     name: tox
@@ -127,8 +132,8 @@
 
 - name: Display installation results
   debug:
-    msg: "Python tools installed successfully: pyenv={{ pyenv_install.changed | default(false) }}, poetry={{ poetry_install.changed }}, tox={{ tox_install.changed }}"
-  when: poetry_install is defined and tox_install is defined
+    msg: "Python tools installed successfully: pyenv={{ pyenv_install.changed | default(false) }}, poetry={{ poetry_install.changed }}, tox={{ tox_install.changed }}, poetry-plugin-export={{ poetry_plugin_export_install.changed | default(false) }}"
+  when: poetry_install is defined and poetry_plugin_export_install is defined and tox_install is defined 
 
 - name: Display pyenv configuration results
   debug:

--- a/darwin/tasks/python.yml
+++ b/darwin/tasks/python.yml
@@ -1,0 +1,43 @@
+---
+# Python Environment Setup
+- name: Install pipx via Homebrew
+  homebrew:
+    name: pipx
+    state: present
+
+- name: Check which pipx path exists
+  stat:
+    path: "{{ item }}"
+  loop:
+    - /usr/local/bin/pipx
+    - /opt/homebrew/bin/pipx
+  register: pipx_path_check
+
+- name: Set pipx path
+  set_fact:
+    pipx_path: "{{ '/opt/homebrew/bin/pipx' if pipx_path_check.results[1].stat.exists else '/usr/local/bin/pipx' }}"
+
+- name: Verify pipx is working
+  command: "{{ pipx_path }} --version"
+  register: pipx_version_check
+  changed_when: false
+
+- name: Install poetry with pipx
+  community.general.pipx:
+    name: poetry
+    state: latest
+    executable: "{{ pipx_path }}"
+  register: poetry_install
+
+- name: Install tox with pipx
+  community.general.pipx:
+    name: tox
+    state: latest
+    executable: "{{ pipx_path }}"
+  register: tox_install
+
+- name: Display installation results
+  debug:
+    msg: "Python tools installed successfully: poetry={{ poetry_install.changed }}, tox={{ tox_install.changed }}"
+  when: poetry_install is defined and tox_install is defined
+  

--- a/darwin/tasks/python.yml
+++ b/darwin/tasks/python.yml
@@ -1,6 +1,18 @@
 ---
 # Python Environment Setup
 
+# Install uv via Homebrew
+- name: Install uv via Homebrew
+  homebrew:
+    name: uv
+    state: present
+  register: uv_install
+
+- name: Verify uv installation
+  command: uv --version
+  register: uv_version_check
+  changed_when: false
+
 # Install pyenv via Homebrew
 - name: Install pyenv via Homebrew
   homebrew:
@@ -132,7 +144,7 @@
 
 - name: Display installation results
   debug:
-    msg: "Python tools installed successfully: pyenv={{ pyenv_install.changed | default(false) }}, poetry={{ poetry_install.changed }}, tox={{ tox_install.changed }}, poetry-plugin-export={{ poetry_plugin_export_install.changed | default(false) }}"
+    msg: "Python tools installed successfully: pyenv={{ pyenv_install.changed | default(false) }}, uv={{ uv_install.changed | default(false) }}, poetry={{ poetry_install.changed }}, tox={{ tox_install.changed }}, poetry-plugin-export={{ poetry_plugin_export_install.changed | default(false) }}"
   when: poetry_install is defined and poetry_plugin_export_install is defined and tox_install is defined 
 
 - name: Display pyenv configuration results
@@ -144,6 +156,11 @@
   debug:
     msg: "pyenv version: {{ pyenv_version_check.stdout | default('not available') }}"
   when: pyenv_version_check is defined and pyenv_version_check.stdout is defined
+
+- name: Display uv version
+  debug:
+    msg: "uv version: {{ uv_version_check.stdout | default('not available') }}"
+  when: uv_version_check is defined and uv_version_check.stdout is defined
 
 - name: Display Python installation results
   debug:

--- a/darwin/tasks/python.yml
+++ b/darwin/tasks/python.yml
@@ -1,5 +1,20 @@
 ---
 # Python Environment Setup
+
+# Install pyenv via Homebrew
+- name: Install pyenv via Homebrew
+  homebrew:
+    name: pyenv
+    state: present
+  register: pyenv_install
+
+- name: Verify pyenv installation
+  shell: pyenv --version
+  register: pyenv_version_check
+  changed_when: false
+  when: pyenv_install.changed
+
+# Install pipx via Homebrew
 - name: Install pipx via Homebrew
   homebrew:
     name: pipx
@@ -36,8 +51,83 @@
     executable: "{{ pipx_path }}"
   register: tox_install
 
+# pyenv shell environment setup
+- name: Backup existing .zshrc
+  copy:
+    src: ~/.zshrc
+    dest: ~/.zshrc.backup.{{ ansible_date_time.epoch }}
+    remote_src: yes
+    backup: yes
+  when: ansible_user_id != 'root'
+
+- name: Check if pyenv is already configured in .zshrc
+  shell: grep -q "pyenv init" ~/.zshrc || echo "not_found"
+  register: pyenv_zshrc_check
+  changed_when: false
+  when: ansible_user_id != 'root'
+
+- name: Add pyenv configuration to .zshrc
+  blockinfile:
+    path: ~/.zshrc
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - pyenv configuration"
+    block: |
+      # pyenv configuration
+      # This configuration enables pyenv to manage Python versions
+      
+      # Set up pyenv root directory
+      export PYENV_ROOT="$HOME/.pyenv"
+      
+      # Add pyenv to PATH
+      export PATH="$PYENV_ROOT/bin:$PATH"
+      
+      # Initialize pyenv shell integration
+      if command -v pyenv 1>/dev/null 2>&1; then
+        eval "$(pyenv init -)"
+      fi
+      
+      # Fix brew doctor warning: prevent pyenv from interfering with Homebrew
+      # This alias removes pyenv shims from PATH when running brew commands
+      alias brew='env PATH="${PATH//$(pyenv root)\/shims:/}" brew'
+  when: 
+    - ansible_user_id != 'root'
+    - pyenv_zshrc_check.stdout == 'not_found'
+  register: zshrc_updated
+
+
+
+# Install Python versions if specified
+- name: Install specified Python versions with pyenv
+  shell: pyenv install {{ item }}
+  loop: "{{ pyenv_python_versions | default([]) }}"
+  when: 
+    - pyenv_python_versions is defined
+    - pyenv_python_versions | length > 0
+  register: python_install_results
+  ignore_errors: true
+
+# Set global Python version if specified
+- name: Set global Python version
+  shell: pyenv global {{ pyenv_global_version }}
+  when: pyenv_global_version is defined
+  register: global_python_set
+
+# Rehash pyenv shims after installations
+- name: Rehash pyenv shims
+  shell: pyenv rehash
+  when: python_install_results is defined and python_install_results | length > 0
+
 - name: Display installation results
   debug:
-    msg: "Python tools installed successfully: poetry={{ poetry_install.changed }}, tox={{ tox_install.changed }}"
+    msg: "Python tools installed successfully: pyenv={{ pyenv_install.changed | default(false) }}, poetry={{ poetry_install.changed }}, tox={{ tox_install.changed }}"
   when: poetry_install is defined and tox_install is defined
+
+- name: Display pyenv configuration results
+  debug:
+    msg: "pyenv configuration: .zshrc updated={{ zshrc_updated.changed | default(false) }}"
+  when: zshrc_updated is defined
+
+- name: Display pyenv version
+  debug:
+    msg: "pyenv version: {{ pyenv_version_check.stdout | default('not available') }}"
+  when: pyenv_version_check is defined and pyenv_version_check.stdout is defined
   


### PR DESCRIPTION
## Overview

This PR adds automated Python development environment setup for macOS using Ansible. It installs and configures essential Python tools including uv for fast package management, pyenv for version management, pipx for isolated tool installation, and poetry/tox for project management.

## Changes

### New Files
- `darwin/tasks/python.yml` — New task file for Python environment automation (170 lines)

### Modified Files
- `darwin/main.yml` — Added import for python tasks with `configure_python` conditional
- `darwin/config.example.yml` — Added Python configuration options

## Features

### ⚡ uv Installation
- Installs [uv](https://github.com/astral-sh/uv) via Homebrew — an extremely fast Python package installer and resolver written in Rust
- Verifies installation with version check

### 🐍 pyenv Installation & Configuration
- Installs pyenv via Homebrew for Python version management
- Configures shell environment in `.zshrc` with:
  - `PYENV_ROOT` environment variable
  - PATH configuration for pyenv
  - Shell integration via `pyenv init`
  - Brew doctor warning fix (alias to prevent PATH conflicts)
- Supports installing multiple Python versions
- Allows setting a global default Python version

### 📦 pipx Setup
- Installs pipx via Homebrew for isolated Python tool installations
- Handles both Intel (`/usr/local/bin`) and Apple Silicon (`/opt/homebrew/bin`) paths

### 🎵 Poetry & Tox
- Installs poetry via pipx for dependency management
- Injects `poetry-plugin-export` for requirements.txt generation
- Installs tox via pipx for test automation

### Summary

| Tool | Installation Method | Purpose |
|------|---------------------|---------|
| **uv** | Homebrew | Fast Python package installer/resolver |
| **pyenv** | Homebrew | Python version management |
| **pipx** | Homebrew | Isolated Python tool installation |
| **poetry** | pipx | Dependency management |
| **poetry-plugin-export** | pipx inject | Export requirements.txt from poetry |
| **tox** | pipx | Test automation |

## Configuration Options

Add to your `darwin/config.yml`:

```yaml
# Enable Python environment setup
configure_python: true

# Python versions to install with pyenv
pyenv_python_versions:
  - "3.11.5"
  - "3.12.0"

# Set global Python version
pyenv_global_version: "3.11.5"
```

## Usage

Run the playbook with the python tag:

```bash
ansible-playbook darwin/main.yml --tags python
```

Or run the full playbook (Python tasks will execute if `configure_python: true`):

```bash
ansible-playbook darwin/main.yml
```

## Idempotency

All tasks are designed to be idempotent:
- ✅ uv/pyenv/pipx installation checks existing state via Homebrew
- ✅ Python version installation skips already-installed versions
- ✅ `.zshrc` configuration uses `blockinfile` with markers to prevent duplicates
- ✅ pipx tool installation uses `state: latest` for safe re-runs

## Dependencies

- Homebrew (installed via `homebrew.yml` task)
- `community.general` collection (for `pipx` module)
