### PR TITLE
macOS zsh Git branch prompt and `.zshrc` block spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ ansible/
 └── README.md             # Documentation
 ```
 
+## Requirements
+
+- **ansible-core 2.16+** (for `ansible.builtin.blockinfile` options such as `prepend_newline` used when editing `~/.zshrc` on macOS). Older versions may lack these parameters.
+
 ## Quick Start
 
 1. Install Ansible:

--- a/darwin/config.example.yml
+++ b/darwin/config.example.yml
@@ -72,6 +72,12 @@ github_work_ssh_host: "work"
 # Set to 'work' to use work account with default SSH key (~/.ssh/id_ed25519)
 github_default_ssh_account: "personal"
 
+# zsh prompt: current Git branch via vcs_info (marked block in ~/.zshrc)
+configure_shell_prompt: true
+# zsh %F{...} color name (e.g. green, cyan) or 0-255 for 256-color
+shell_prompt_git_branch_color: green
+shell_prompt_git_action_color: yellow
+
 # Python Environment Configuration
 # Set to 'true' to configure Python development tools (pyenv, pipx, poetry, tox)
 configure_python: false
@@ -115,7 +121,7 @@ cursor_plugins:
   - "ms-azuretools.vscode-docker"         # Docker support
   - "eamodio.gitlens"                     # Git supercharged
 
-Keys merged into Cursor User settings.json (optional; preserves other user keys)
+# Keys merged into Cursor User settings.json (optional; preserves other user keys)
 cursor_user_settings_managed:
   python.terminal.activateEnvironment: false
 

--- a/darwin/config.example.yml
+++ b/darwin/config.example.yml
@@ -73,7 +73,7 @@ github_work_ssh_host: "work"
 github_default_ssh_account: "personal"
 
 # zsh prompt: current Git branch via vcs_info (marked block in ~/.zshrc)
-configure_shell_prompt: true
+configure_shell_prompt: false
 # zsh %F{...} color name (e.g. green, cyan) or 0-255 for 256-color
 shell_prompt_git_branch_color: green
 shell_prompt_git_action_color: yellow

--- a/darwin/main.yml
+++ b/darwin/main.yml
@@ -46,6 +46,9 @@
       when: configure_python
       tags: ['python']
 
+    - import_tasks: tasks/shell-prompt.yml
+      tags: ['shell', 'shell-prompt']
+
     - import_tasks: tasks/aws-vault.yml
       when: configure_aws_vault
       tags: ['aws', 'aws-vault'] 

--- a/darwin/tasks/python.yml
+++ b/darwin/tasks/python.yml
@@ -96,9 +96,10 @@
   when: ansible_user_id != 'root'
 
 - name: Add pyenv configuration to .zshrc
-  blockinfile:
+  ansible.builtin.blockinfile:
     path: ~/.zshrc
     marker: "# {mark} ANSIBLE MANAGED BLOCK - pyenv configuration"
+    prepend_newline: true
     block: |
       # pyenv configuration
       # This configuration enables pyenv to manage Python versions

--- a/darwin/tasks/shell-prompt.yml
+++ b/darwin/tasks/shell-prompt.yml
@@ -1,0 +1,20 @@
+---
+# Inject zsh vcs_info Git branch prompt into ~/.zshrc (lookup-rendered Jinja, no extra files).
+- name: Inject zsh Git branch prompt into .zshrc
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_env.HOME }}/.zshrc"
+    create: true
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - zsh prompt"
+    block: "{{ lookup('template', 'zsh-prompt.j2') | trim }}"
+  when:
+    - configure_shell_prompt | default(false)
+    - ansible_user_id != 'root'
+
+- name: Remove zsh Git branch prompt block from .zshrc
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_env.HOME }}/.zshrc"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - zsh prompt"
+    state: absent
+  when:
+    - not (configure_shell_prompt | default(false))
+    - ansible_user_id != 'root'

--- a/darwin/tasks/shell-prompt.yml
+++ b/darwin/tasks/shell-prompt.yml
@@ -5,6 +5,7 @@
     path: "{{ ansible_env.HOME }}/.zshrc"
     create: true
     marker: "# {mark} ANSIBLE MANAGED BLOCK - zsh prompt"
+    prepend_newline: true
     block: "{{ lookup('template', 'zsh-prompt.j2') | trim }}"
   when:
     - configure_shell_prompt | default(false)

--- a/darwin/templates/zsh-prompt.j2
+++ b/darwin/templates/zsh-prompt.j2
@@ -1,0 +1,16 @@
+# --- Git branch in prompt (zsh vcs_info) ---
+# Shows current branch (and merge/rebase state) when cwd is inside a Git repo.
+# Colors come from shell_prompt_git_branch_color / shell_prompt_git_action_color in config.
+autoload -Uz vcs_info
+zstyle ':vcs_info:*' enable git
+zstyle ':vcs_info:*' check-for-changes false
+zstyle ':vcs_info:git:*' formats '(%F{ {{- shell_prompt_git_branch_color | default('green') -}} }%b%f)'
+zstyle ':vcs_info:git:*' actionformats '(%F{ {{- shell_prompt_git_action_color | default('yellow') -}} }%b|%a%f)'
+precmd_functions+=( precmd_vcs_info_ansible )
+precmd_vcs_info_ansible() {
+  vcs_info
+}
+# --- End Git / vcs_info ---
+
+setopt PROMPT_SUBST
+PROMPT='%n@%m %1~ ${vcs_info_msg_0_} %# '


### PR DESCRIPTION
## Overview

This change adds an optional Darwin playbook feature that injects a Git-aware zsh prompt into `~/.zshrc` using only zsh `vcs_info` (no Oh My Zsh, Starship, or extra installed snippet files). Prompt content is maintained as Jinja under `darwin/templates/` and applied with `ansible.builtin.blockinfile` plus `lookup('template', ...)`.

It also improves readability of Ansible-managed sections in `~/.zshrc` by enabling `prepend_newline` on `ansible.builtin.blockinfile` for both the pyenv block and the shell prompt block, so a blank line appears before each `# BEGIN ANSIBLE MANAGED BLOCK …` line when the module updates that section.

The root `README.md` documents **ansible-core 2.16+** as a requirement because `prepend_newline` was added in that release line.

## Changes

### New files

| Path | Purpose |
|------|---------|
| `darwin/tasks/shell-prompt.yml` | Injects or removes the marked zsh prompt block in `~/.zshrc`. |
| `darwin/templates/zsh-prompt.j2` | Jinja template rendered into the `blockinfile` body (Git branch colors and `vcs_info` setup). |

### Modified files

| Path | Purpose |
|------|---------|
| `darwin/main.yml` | Imports `tasks/shell-prompt.yml` with tags `shell` and `shell-prompt`. |
| `darwin/config.yml` | Adds `configure_shell_prompt`, `shell_prompt_git_branch_color`, `shell_prompt_git_action_color`. |
| `darwin/config.example.yml` | Same optional variables with documented defaults. |
| `darwin/tasks/python.yml` | Pyenv `blockinfile` uses `ansible.builtin.blockinfile` and `prepend_newline: true`. |
| `README.md` | Requirements section for ansible-core 2.16+. |

## Behavior

### Shell prompt (opt-in)

- Set `configure_shell_prompt: true` in `darwin/config.yml`.
- Ansible renders `zsh-prompt.j2` and inserts it between unique markers (`ANSIBLE MANAGED BLOCK - zsh prompt`).
- The prompt shows the current Git branch (and action state when merging/rebasing) using `vcs_info`, with configurable `%F{…}` colors via `shell_prompt_git_branch_color` and `shell_prompt_git_action_color`.
- Disabling the flag removes only that marked block (`state: absent`); the rest of `~/.zshrc` is untouched.
- Tasks skip `root` for parity with the pyenv `.zshrc` edits.

### Spacing between marker blocks

- `prepend_newline: true` on the pyenv and shell prompt `blockinfile` tasks asks Ansible to ensure one blank line **before** the opening `# BEGIN …` line, idempotently.
- The Homebrew `lineinfile` entry is unchanged (no `BEGIN`/`END` markers); spacing above that line is out of scope for this PR.

### Requirements

- **ansible-core 2.16 or newer** for `prepend_newline` on `ansible.builtin.blockinfile`.

## Configuration

Add or adjust in `darwin/config.yml`:

```yaml
configure_shell_prompt: false   # set true to enable
shell_prompt_git_branch_color: green    # zsh color name or 0–255
shell_prompt_git_action_color: yellow
```

## Usage

Run only shell prompt tasks:

```bash
ansible-playbook -i inventory/darwin darwin/main.yml --tags shell
```

Or run the full playbook (shell prompt applies when `configure_shell_prompt` is true).

## Migration notes

- **Pyenv block:** The pyenv task still runs only when `pyenv init` is not already present in `.zshrc`. Existing machines that already have the pyenv block will not pick up `prepend_newline` for that block until the block is rewritten (for example after a one-time manual adjustment or a deliberate re-run path). New installs get correct spacing when the block is first written.
- **Shell prompt block:** First run after enabling adds the block and spacing; subsequent runs should report no change unless the template or variables change.

## Testing suggestions

- Run the playbook twice with `configure_shell_prompt: true` and confirm the second run is a no-op for the inject task.
- Open a new terminal: inside a Git repo, confirm branch (and colors); outside a repo, confirm no stray branch text beyond `vcs_info` defaults.
- Set `configure_shell_prompt: false` and confirm the marked block is removed.
