### PR TITLE
feat: gh CLI multi-account support for GitHub multi-identity

### DIFF
--- a/darwin/config.example.yml
+++ b/darwin/config.example.yml
@@ -58,12 +58,14 @@ configure_github_multi_identity: false
 # Personal GitHub account settings (used for all repositories except work directory)
 github_personal_email: "your-personal-email@example.com"
 git_personal_name: "Your Personal Name"
+github_personal_username: "your-personal-github-username"
 github_personal_directory: "~/repositories/personal/"
 github_personal_ssh_host: "personal"
 
 # Work GitHub account settings (used only for repositories in work directory)
 github_work_email: "your-work-email@company.com"
 git_work_name: "Your Work Name"
+github_work_username: "your-work-github-username"
 github_work_directory: "~/repositories/work/"
 github_work_ssh_host: "work"
 

--- a/darwin/main.yml
+++ b/darwin/main.yml
@@ -42,6 +42,10 @@
       when: configure_github_multi_identity
       tags: ['github', 'github-multi-identity']
 
+    - import_tasks: tasks/github-gh.yml
+      when: configure_github_multi_identity
+      tags: ['github', 'github-multi-identity', 'gh']
+
     - import_tasks: tasks/python.yml
       when: configure_python
       tags: ['python']

--- a/darwin/tasks/github-gh.yml
+++ b/darwin/tasks/github-gh.yml
@@ -1,0 +1,41 @@
+---
+# gh CLI multi-identity: zsh wrapper selects account by directory (mirrors git includeIf).
+- name: Inject gh multi-identity wrapper into .zshrc
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_env.HOME }}/.zshrc"
+    create: true
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - gh multi-identity"
+    prepend_newline: true
+    block: "{{ lookup('template', 'zsh-gh-multi-identity.j2') | trim }}"
+  when:
+    - configure_github_multi_identity | default(false)
+    - ansible_user_id != 'root'
+
+- name: Remove gh multi-identity block from .zshrc
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_env.HOME }}/.zshrc"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - gh multi-identity"
+    state: absent
+  when:
+    - not (configure_github_multi_identity | default(false))
+    - ansible_user_id != 'root'
+
+- name: Show gh CLI multi-identity setup instructions
+  debug:
+    msg: |
+      gh CLI multi-identity wrapper installed in ~/.zshrc.
+
+      Authenticate both GitHub accounts once (OAuth cannot be automated):
+
+        gh auth login    # log in as {{ github_personal_username }} (personal)
+        gh auth login    # log in as {{ github_work_username }} (work)
+
+      Verify:
+
+        gh auth status
+        cd {{ github_work_directory | default('~/repositories/work/') }} && gh api user -q .login
+        cd ~ && gh api user -q .login
+
+      Under {{ github_work_directory | default('~/repositories/work/') }}, gh uses {{ github_work_username }}.
+      Everywhere else, gh uses {{ github_personal_username }}.
+  when: configure_github_multi_identity | default(false)

--- a/darwin/tasks/github-multi-identity.yml
+++ b/darwin/tasks/github-multi-identity.yml
@@ -55,4 +55,9 @@
       {% if github_default_ssh_account | default('personal') == 'personal' %}- Personal repositories: All other directories (default behavior){% endif %}
       {% if github_default_ssh_account | default('personal') == 'work' %}- Personal repositories: {{ github_personal_directory | default('~/repositories/personal/') }}{% endif %}
       {% if github_default_ssh_account | default('personal') == 'work' %}- Work repositories: All other directories (default behavior){% endif %}
-  when: configure_github_multi_identity | default(false) 
+      
+      gh CLI (directory-based account for PRs and API):
+      - Personal GitHub user: {{ github_personal_username }}
+      - Work GitHub user: {{ github_work_username }}
+      - Run once: gh auth login (for each account), then open a new shell or run: source ~/.zshrc
+  when: configure_github_multi_identity | default(false)

--- a/darwin/tasks/validate-ssh-github-config.yml
+++ b/darwin/tasks/validate-ssh-github-config.yml
@@ -207,11 +207,13 @@
       - github_work_email
       - git_personal_name
       - git_work_name
+      - github_personal_username
+      - github_work_username
       
       Please configure these variables in your config.yml file.
   when: 
     - configure_github_multi_identity | default(false)
-    - (github_personal_email is not defined or github_work_email is not defined or git_personal_name is not defined or git_work_name is not defined)
+    - (github_personal_email is not defined or github_work_email is not defined or git_personal_name is not defined or git_work_name is not defined or github_personal_username is not defined or github_work_username is not defined)
 
 - name: Show configuration summary
   debug:

--- a/darwin/templates/gitconfig-personal.j2
+++ b/darwin/templates/gitconfig-personal.j2
@@ -1,3 +1,6 @@
 [user]
     name = {{ git_personal_name | default('Your Personal Name') }}
     email = {{ github_personal_email | default('your-personal-email@example.com') }}
+
+[github]
+    user = {{ github_personal_username }}

--- a/darwin/templates/gitconfig-work.j2
+++ b/darwin/templates/gitconfig-work.j2
@@ -1,3 +1,6 @@
 [user]
     name = {{ git_work_name | default('Your Work Name') }}
     email = {{ github_work_email | default('your-work-email@company.com') }}
+
+[github]
+    user = {{ github_work_username }}

--- a/darwin/templates/zsh-gh-multi-identity.j2
+++ b/darwin/templates/zsh-gh-multi-identity.j2
@@ -1,0 +1,31 @@
+# --- gh CLI: directory-based GitHub account (default: personal) ---
+# Work tree: {{ github_work_directory | default('~/repositories/work/') }}
+{% set work_dir = github_work_directory | default('~/repositories/work/') | regex_replace('/$', '') | regex_replace('^~/', '') %}
+{% set personal_dir = github_personal_directory | default('~/repositories/personal/') | regex_replace('/$', '') | regex_replace('^~/', '') %}
+gh() {
+  local work_dir="$HOME/{{ work_dir }}"
+  local personal_user="{{ github_personal_username }}"
+  local work_user="{{ github_work_username }}"
+{% if github_default_ssh_account | default('personal') == 'personal' %}
+  local target_user="$personal_user"
+
+  if [[ "$PWD" == "$work_dir"* ]]; then
+    target_user="$work_user"
+  fi
+{% else %}
+  local personal_dir="$HOME/{{ personal_dir }}"
+  local target_user="$work_user"
+
+  if [[ "$PWD" == "$personal_dir"* ]]; then
+    target_user="$personal_user"
+  fi
+{% endif %}
+
+  local token
+  token=$(command gh auth token --user "$target_user" 2>/dev/null) || {
+    echo "gh: no token for GitHub user '$target_user' (run: gh auth login)" >&2
+    return 1
+  }
+  GH_TOKEN="$token" command gh "$@"
+}
+# --- End gh multi-identity ---


### PR DESCRIPTION
## Summary

- Add `github_personal_username` and `github_work_username` to multi-identity git config (`[github] user` in conditional snippets) and validation
- Add zsh `gh` wrapper that uses the work GitHub account under `github_work_directory` and defaults to personal elsewhere (`GH_TOKEN` per invocation)
- Wire `darwin/tasks/github-gh.yml` into the playbook when `configure_github_multi_identity` is enabled

## Test plan

- [x] Set `configure_github_multi_identity: true` plus SSH multi-identity in local `darwin/config.yml`
- [x] Run `ansible-playbook -i inventory/darwin darwin/main.yml --tags github`
- [x] Run `gh auth login` for both personal and work accounts
- [x] `source ~/.zshrc` and verify `gh api user -q .login` returns personal username from this repo
- [x] `cd ~/repositories/takemobiteam/<repo>` and verify `gh api user -q .login` returns work username
- [x] `gh pr create` (or other API command) succeeds in each context